### PR TITLE
SDK-174 Added JIRA support for enriching data and creating childissues_to_epic.csv

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+### Description of Changes
+
+What has been changed? If this is more than bug fixes we should consider incrementing the minor 
+version number. For non backwards compatible changes we need to increment the major version number.
+
+### Documentation
+
+Provide links to all relevant documentation that should be updated before asking for the PR to be reviewed. If this section is not relevant please write 'Not Applicable' rather than deleting the section.
+
+### Risks & Impacts
+
+The potential risks of this change as a bullet pointed list and how it might impact the wider sdk. Please consider how easily it would be to rollback these changes if they cause problems. Are there breaking changes?
+
+### Testing
+
+How have the changes been tested and the potential risks mitigated?
+
+### Compare (For layered PRs)
+
+Generate compare URL from https://github.com/ebx/ebx-linkedin-sdk/compare so that it's easily accessible. This is ONLY REQUIRED FOR COMPLICATED, DEPENDENT OR LAYERED PRs. Feel free to delete this section if not required.
+
+## Final Checklist
+
+Please tick once completed.
+
+- [ ] Build passes.
+- [ ] Versioning considered (the version number in this PR is inline with semantic 
+versioning requirements).
+- [ ] Change log has been updated.

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ export*.csv
 *cycle_times_hours.csv
 author_names_to_squads.csv
 preferred_author_names.csv
-
+childissues_to_epic.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Initial release
 
-## 1.1.0 (June 5, 2023)
+## 2.0.0 (June 5, 2023)
 
-* Project JAVA version upgraded to 17, due to new dependencies.
+* Project JAVA version upgraded to 17, due to new dependencies. This caused the major version bump.
 * Added optional analyser classes to allow for additional PR enrichment. For example with JIRA data.
 * After PR exports creates a cross reference lookup document named childissues_to_epic.csv which 
   can be used to determine work types for all tracked issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 * Initial release
 
-## 2.0.0 (May 5, 2023)
+## 1.1.0 (May 5, 2023)
 
-* Breaking changes to the analyser classes to allow for additional PR enrichers.
+* Added optional analyser classes to allow for additional PR enrichment. For example with JIRA data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 1.1.0 (June 5, 2023)
 
+* Project JAVA version upgraded to 17, due to new dependencies.
 * Added optional analyser classes to allow for additional PR enrichment. For example with JIRA data.
 * After PR exports creates a cross reference lookup document named childissues_to_epic.csv which 
   can be used to determine work types for all tracked issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Initial release
 
-## 1.1.0 (May 5, 2023)
+## 1.1.0 (June 5, 2023)
 
 * Added optional analyser classes to allow for additional PR enrichment. For example with JIRA data.
+* After PR exports creates a cross reference lookup document named childissues_to_epic.csv which 
+  can be used to determine work types for all tracked issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# ebx-linkedin-sdk Changelog
+
+## 1.0.0 (November 21, 2022)
+
+* Initial release
+
+## 2.0.0 (May 5, 2023)
+
+* Breaking changes to the analyser classes to allow for additional PR enrichers.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ebx-github-cycletime itself is open source software released under the terms of 
 
 ## Getting Started
 
-At the time of writing the application is intended to be run from source (>=Java 14). Use the 
+At the time of writing the application is intended to be run from source (>=Java 17). Use the 
 following steps to get started:
 
 1. Download the source.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We've added basic support to retrieve data from JIRA, a proof of concept
 if you will. If JIRA credentials (as environment variables) are provided and PR titles are in the 
 expected JIRAEpicWorkTypeEnricher.EXPECTED_ISSUE_KEY_PATTERN the default app configuration will 
 build a list of all issue keys and their associated parent epic. Exported as childissues_to_epic.csv. 
-Any existing  file is used as a cache on subsequent executions to avoid repeating the same lookups.
+Any existing file is used as a cache on subsequent executions to avoid repeating the same lookups.
 
 Required environment variable keys, with examples are:
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ Required environment variable keys, with examples are:
 
 * JIRA_URL = https://yourdomain.atlassian.net
 * JIRA_EMAIL = marc@yourdomain.com
-* JIRA_API_TOKEN = (can be created here - https://id.atlassian.
-  com/manage-profile/security/api-tokens)
+* JIRA_API_TOKEN = (can be created here - https://id.atlassian.com/manage-profile/security/api-tokens)
 
 ### Helpful notes:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ analyser.analyse();
 // ...
 ```
 
+### (Optional) Integrating with JIRA data
+
+We've added basic support to retrieve data from JIRA, a proof of concept 
+if you will. If JIRA credentials (as environment variables) are provided and PR titles are in the 
+expected JIRAEpicWorkTypeEnricher.EXPECTED_ISSUE_KEY_PATTERN the default app configuration will 
+build a list of all issue keys and their associated parent epic. Exported as childissues_to_epic.csv. 
+Any existing  file is used as a cache on subsequent executions to avoid repeating the same lookups.
+
+Required environment variable keys, with examples are:
+
+* JIRA_URL = https://yourdomain.atlassian.net
+* JIRA_EMAIL = marc@yourdomain.com
+* JIRA_API_TOKEN = (can be created here - https://id.atlassian.
+  com/manage-profile/security/api-tokens)
+
 ### Helpful notes:
 
 #### Calculating PR reviewed by

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.echobox</groupId>
     <artifactId>ebx-github-cycletime</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.echobox</groupId>
     <artifactId>ebx-github-cycletime</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.echobox</groupId>
     <artifactId>ebx-github-cycletime</artifactId>
-    <version>2.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,17 @@
             <version>1.313</version>
         </dependency>
         <dependency>
+            <groupId>com.chavaillaz</groupId>
+            <artifactId>jira-client</artifactId>
+            <version>1.1.5</version>
+        </dependency>
+        <!-- Required as optional dependency include for jira-client -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>31.1-jre</version>
@@ -71,11 +82,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.9.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.chavaillaz</groupId>
-            <artifactId>jira-client</artifactId>
-            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -117,20 +123,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>14</maven.compiler.source>
-        <maven.compiler.target>14</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <junit.version>5.9.1</junit.version>
     </properties>
 
@@ -71,6 +71,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.chavaillaz</groupId>
+            <artifactId>jira-client</artifactId>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/echobox/github/cycletime/Main.java
+++ b/src/main/java/com/echobox/github/cycletime/Main.java
@@ -17,14 +17,6 @@
 
 package com.echobox.github.cycletime;
 
-import com.chavaillaz.jira.client.IssueClient;
-import com.chavaillaz.jira.client.JiraClient;
-import com.chavaillaz.jira.client.apache.ApacheHttpJiraClient;
-import com.chavaillaz.jira.domain.BasicIssue;
-import com.chavaillaz.jira.domain.CommonFields;
-import com.chavaillaz.jira.domain.Fields;
-import com.chavaillaz.jira.domain.Issue;
-import com.chavaillaz.jira.domain.IssueType;
 import com.echobox.github.cycletime.analyse.AnalysisCleanup;
 import com.echobox.github.cycletime.analyse.OrgAnalyser;
 import com.echobox.github.cycletime.analyse.PRAnalyser;
@@ -33,6 +25,7 @@ import com.echobox.github.cycletime.data.AnalysedPR;
 import com.echobox.github.cycletime.data.AuthorsToSquadsCSVDAO;
 import com.echobox.github.cycletime.data.PreferredAuthorNamesCSVDAO;
 import com.echobox.github.cycletime.data.PullRequestCSVDAO;
+import com.echobox.github.cycletime.enrichment.jira.JIRAEpicWorkTypeEnricher;
 import com.echobox.github.cycletime.providers.kohsuke.PullRequestKohsuke;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
@@ -52,11 +45,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Let's download some github information!
@@ -205,43 +195,14 @@ public class Main {
       
       AnalysedPR pr = allPRs.get(0);
       
-      String ticketNumber = pr.getPrTitle().split(" ")[0];
-      
       String jiraURL = System.getenv("JIRA_URL");
       String jiraEmail = System.getenv("JIRA_EMAIL");
       String jiraAPIToken = System.getenv("JIRA_API_TOKEN");
       
-      JiraClient<Issue> client = ApacheHttpJiraClient.jiraApacheClient(jiraURL)
-          .withAuthentication(jiraEmail, jiraAPIToken);
-
-      IssueClient<Issue> issueClient = client.getIssueClient();
+      JIRAEpicWorkTypeEnricher enricher = new JIRAEpicWorkTypeEnricher(jiraURL, jiraEmail,
+          jiraAPIToken);
       
-      CompletableFuture<Issue> issue = issueClient.getIssue(ticketNumber);
-      Issue issue1 = issue.get();
-      Fields fields = issue1.getFields();
-      
-      BasicIssue parent = fields.getParent();
-      
-      CommonFields fields1 = parent.getFields();
-      IssueType issueType = fields1.getIssueType();
-      
-      CompletableFuture<Issue> issue2 = issueClient.getIssue(parent.getKey());
-      Issue issue3 = issue2.get();
-      Fields fields2 = issue3.getFields();
-      
-      BasicIssue parent1 = fields2.getParent();
-      CommonFields fields3 = parent1.getFields();
-      IssueType issueType1 = fields3.getIssueType();
-      
-      CompletableFuture<Issue> issue4 = issueClient.getIssue(parent1.getKey());
-      Issue issue5 = issue4.get();
-      Map<String, Object> customFields = issue5.getFields().getCustomFields();
-      
-      //customfield_12732
-      LinkedHashMap customfield12732 = (LinkedHashMap) customFields.get("customfield_12732");
-      String workType = (String) customfield12732.get("value");
-      
-      LOGGER.debug("Found epic of issue " + ticketNumber);
+      List<String> enrichments = enricher.getEnrichments(pr);
     }
   }
 

--- a/src/main/java/com/echobox/github/cycletime/Main.java
+++ b/src/main/java/com/echobox/github/cycletime/Main.java
@@ -121,8 +121,8 @@ public class Main {
     LOGGER.debug("Rate limit remaining in current hour window - "
         + rateLimitStart.getCore().getRemaining());
     
-    performExportAndAnalysis(githubOrg);
-    cleanupAnalysis();
+    performExportAndBaseAnalysis(githubOrg);
+    analysisCleanup();
     aggregateCycleTimes();
 
     buildEpicTypesFromIssueKeysExport();
@@ -134,7 +134,7 @@ public class Main {
     LOGGER.debug("Done. Used the following rate limit quota - " + usedRateLimit);
   }
   
-  private static void performExportAndAnalysis(GHOrganization githubOrg)
+  private static void performExportAndBaseAnalysis(GHOrganization githubOrg)
       throws Exception {
 
     boolean exportAlreadyExists = new File(RAW_CSV_FILENAME).exists();
@@ -171,7 +171,7 @@ public class Main {
     }
   }
 
-  private static void cleanupAnalysis() throws Exception {
+  private static void analysisCleanup() throws Exception {
 
     List<AnalysedPR> uncleanedPRs;
     try (PullRequestCSVDAO csv = new PullRequestCSVDAO(RAW_CSV_FILENAME, persistWithTimezone,

--- a/src/main/java/com/echobox/github/cycletime/data/AnalysedPR.java
+++ b/src/main/java/com/echobox/github/cycletime/data/AnalysedPR.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -51,4 +52,12 @@ public class AnalysedPR {
   
   private List<String> additionalEnrichments;
 
+  public synchronized void appendEnrichments(List<String> enrichments) {
+    if (additionalEnrichments == null) {
+      additionalEnrichments = new ArrayList<>();
+    }
+    
+    additionalEnrichments.addAll(enrichments);
+  }
+  
 }

--- a/src/main/java/com/echobox/github/cycletime/data/ChildIssueKeyToEpicCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/ChildIssueKeyToEpicCSVDAO.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.github.cycletime.data;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A CSV DAO for issue key to epic information
+ * @author MarcF
+ */
+public class ChildIssueKeyToEpicCSVDAO implements AutoCloseable {
+  
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private final Writer csvWriter;
+  private final Reader csvReader;
+  
+  public ChildIssueKeyToEpicCSVDAO(String filename, boolean append) throws IOException {
+    this.csvWriter = new PrintWriter(new FileWriter(filename, append));
+    this.csvReader = new FileReader(filename);
+  }
+  
+  public synchronized void writeCSVHeader() throws IOException {
+    String headers = "ChildIssueKey,EpicIssueKey,WorkType,Title";
+    csvWriter.write(headers + "\n");
+    csvWriter.flush();
+  }
+  
+  public synchronized void writeToCSV(List<Epic> epics) throws IOException  {
+    for (Epic epic : epics) {
+      writeToCSV(epic);
+    }
+  }
+  
+  public synchronized void writeToCSV(Epic epic) throws IOException  {
+    String safeCSVTitle = StringEscapeUtils.escapeCsv(epic.getTitle());
+    
+    String csvLineToWrite = String.format("%s,%s,%s,%s",
+        epic.getChildIssueKey(),
+        epic.getEpicIssueKey(),
+        epic.getWorkType(),
+        safeCSVTitle);
+    
+    csvWriter.write(csvLineToWrite + "\n");
+    csvWriter.flush();
+  }
+  
+  /**
+   * Load all child issue keys to epics
+   * @return Map of KEY - Child issue key, VALUE - The associated epic
+   * @throws IOException If the configured CSV file cannot be read
+   */
+  public synchronized Map<String, Epic> loadAllEpics() throws IOException {
+
+    if (csvReader == null) {
+      return new HashMap<>();
+    }
+
+    CSVFormat format = CSVFormat.Builder.create().setHeader().build();
+    Iterable<CSVRecord> records = format.parse(csvReader);
+
+    return StreamSupport.stream(records.spliterator(), false)
+        .map(r -> parseRecord(r))
+        .collect(Collectors.toMap(r -> r.getChildIssueKey(), r -> r));
+  }
+  
+  private Epic parseRecord(CSVRecord record) {
+    
+    String childIssueKey = record.get("ChildIssueKey");
+    String epicIssueKey = record.get("EpicIssueKey");
+    String title  = record.get("Title");
+    String workType = record.get("WorkType");
+    
+    return new Epic(childIssueKey, epicIssueKey, title, workType);
+  }
+  
+  @Override
+  public void close() throws Exception {
+    if (csvReader != null) {
+      csvReader.close();
+    }
+  }
+}

--- a/src/main/java/com/echobox/github/cycletime/data/Epic.java
+++ b/src/main/java/com/echobox/github/cycletime/data/Epic.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.github.cycletime.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Epic {
+  
+  private String childIssueKey;
+  private String epicIssueKey;
+  private String title;
+  private String workType;
+
+}

--- a/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
@@ -88,7 +88,7 @@ public class PullRequestCSVDAO implements AutoCloseable {
     String headers = "UTCMergedDateTime,MonthIndex,Repo-PRNum,Title,PRAuthor,CodingTimeSecs,"
         + "PickupTimeSecs,ReviewTimeSecs,Review1,Review2,Review3,Review4,Review5,Review6";
     
-    if (additionalHeaders != null) {
+    if (additionalHeaders != null && !additionalHeaders.isEmpty()) {
       headers += "," + additionalHeaders.stream().collect(Collectors.joining(","));
     }
     

--- a/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
@@ -34,6 +34,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,6 +53,8 @@ public class PullRequestCSVDAO implements AutoCloseable {
   private static final DateTimeFormatter fullFormat = DateTimeFormatter.ofPattern(ISO_FORMAT);
   private static final DateTimeFormatter monthOnlyFormat = DateTimeFormatter.ofPattern("MM");
 
+  private static final int MAX_REVIEWS = 6;
+  
   private final Writer csvWriter;
   private final Reader csvReader;
   private final ZoneId persistWithTimezone;
@@ -72,10 +75,26 @@ public class PullRequestCSVDAO implements AutoCloseable {
    * @throws IOException If the write fails
    */
   public synchronized void writeCSVHeader() throws IOException {
-    csvWriter.write("UTCMergedDateTime,MonthIndex,Repo-PRNum,Title,PRAuthor,CodingTimeSecs,"
-        + "PickupTimeSecs,ReviewTimeSecs,Review1,Review2,Review3,Review4,Review5,Review6\n");
+    writeCSVHeader(new ArrayList<>());
   }
   
+  /**
+   * Write the CSV header for PR analysis
+   * @param additionalHeaders Append the additional heads to the end of the standard ones
+   * @throws IOException If the write fails
+   */
+  public synchronized void writeCSVHeader(List<String> additionalHeaders) throws IOException {
+    
+    String headers = "UTCMergedDateTime,MonthIndex,Repo-PRNum,Title,PRAuthor,CodingTimeSecs,"
+        + "PickupTimeSecs,ReviewTimeSecs,Review1,Review2,Review3,Review4,Review5,Review6";
+    
+    if (additionalHeaders != null) {
+      headers += "," + additionalHeaders.stream().collect(Collectors.joining(","));
+    }
+    
+    csvWriter.write(headers + "\n");
+  }
+
   public synchronized void writeToCSV(List<AnalysedPR> analysedPRs,
       Map<String, String> preferredAuthorNames) throws IOException {
     for (AnalysedPR analysedPR : analysedPRs) {
@@ -96,19 +115,27 @@ public class PullRequestCSVDAO implements AutoCloseable {
     String repoNum = analysedPR.getRepoName() + "/" + analysedPR.getPrNum();
     String safeCSVTitle = StringEscapeUtils.escapeCsv(analysedPR.getPrTitle());
     String authorName = analysedPR.getPrAuthorStr();
-  
-    Stream<String> reviewedByStream = analysedPR.getPrReviewedByList().stream();
+    
+    List<String> prReviewedByList = analysedPR.getPrReviewedByList();
+    Stream<String> reviewedByStream = prReviewedByList.stream().limit(MAX_REVIEWS);
     
     if (preferredAuthorNames != null) {
       authorName = preferredAuthorNames.getOrDefault(authorName, authorName);
       reviewedByStream = reviewedByStream.map(n -> preferredAuthorNames.getOrDefault(n, n));
     }
-  
-    String reviewUserNameStr = reviewedByStream.collect(Collectors.joining(","));
+
+    String reviewUserNameStr = reviewedByStream.collect(Collectors.joining(",")) + ",";
+    
+    //Ensure we fill out the columns in the CSV with empty data if needed
+    if (prReviewedByList.size() < MAX_REVIEWS) {
+      reviewUserNameStr += Collections.nCopies(
+          MAX_REVIEWS - Math.max(prReviewedByList.size(), 1), "")
+          .stream().collect(Collectors.joining(","));
+    }
     
     ZonedDateTime dtToPrint = analysedPR.getMergedAtDate().withZoneSameInstant(persistWithTimezone);
     
-    csvWriter.write(String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+    String csvLineToWrite = String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s",
         fullFormat.format(dtToPrint),
         monthOnlyFormat.format(dtToPrint),
         repoNum,
@@ -117,8 +144,16 @@ public class PullRequestCSVDAO implements AutoCloseable {
         analysedPR.getCodingTimeSecs(),
         analysedPR.getPickupTimeSecs(),
         analysedPR.getReviewTimeSecs(),
-        reviewUserNameStr));
-  
+        reviewUserNameStr);
+    
+    if (analysedPR.getAdditionalEnrichments() != null) {
+      for (String element : analysedPR.getAdditionalEnrichments()) {
+        csvLineToWrite += String.format(",%s", element);
+      }
+    }
+    
+    csvWriter.write(csvLineToWrite + "\n");
+
     csvWriter.flush();
     if (analysedPRs != null) {
       analysedPRs.add(analysedPR);

--- a/src/main/java/com/echobox/github/cycletime/enrichment/PREnricher.java
+++ b/src/main/java/com/echobox/github/cycletime/enrichment/PREnricher.java
@@ -15,40 +15,29 @@
  * limitations under the License.
  */
 
-package com.echobox.github.cycletime.data;
+package com.echobox.github.cycletime.enrichment;
 
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import com.echobox.github.cycletime.data.AnalysedPR;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 
-@Getter
-@Setter
-@RequiredArgsConstructor
-public class AnalysedPR {
+/**
+ * Provides enrichment for an AnalysedPR. For example data from JIRA.
+ * @author MarcF
+ */
+public interface PREnricher {
   
-  @NonNull
-  private String repoName;
-  @NonNull
-  private ZonedDateTime mergedAtDate;
-  @NonNull
-  private int prNum;
-  @NonNull
-  private String prTitle;
-  @NonNull
-  private String prAuthorStr;
-  @NonNull
-  private long codingTimeSecs;
-  @NonNull
-  private long pickupTimeSecs;
-  @NonNull
-  private long reviewTimeSecs;
-  @NonNull
-  private List<String> prReviewedByList;
+  /**
+   * Provide the enrichment headers names provided by this implementation
+   * @return The enrichment header names
+   */
+  List<String> getEnrichmentHeaderNames();
   
-  private List<String> additionalEnrichments;
+  /**
+   * Given an analysed PR provide the expected enrichments
+   * @param analysedPR The PR for which to provide the enrichments
+   * @return The enrichments, which should equal in count the enrichment headers
+   */
+  List<String> getEnrichments(AnalysedPR analysedPR) throws Exception;
 
 }

--- a/src/main/java/com/echobox/github/cycletime/enrichment/PREnricher.java
+++ b/src/main/java/com/echobox/github/cycletime/enrichment/PREnricher.java
@@ -34,10 +34,9 @@ public interface PREnricher {
   List<String> getEnrichmentHeaderNames();
   
   /**
-   * Given an analysed PR provide the expected enrichments
-   * @param analysedPR The PR for which to provide the enrichments
-   * @return The enrichments, which should equal in count the enrichment headers
+   * Given an analysed PR add the expected enrichments
+   * @param analysedPR The PR for which to add the enrichments
    */
-  List<String> getEnrichments(AnalysedPR analysedPR) throws Exception;
+  void addEnrichmentsToPR(AnalysedPR analysedPR) throws Exception;
 
 }

--- a/src/main/java/com/echobox/github/cycletime/enrichment/jira/JIRAEpicWorkTypeEnricher.java
+++ b/src/main/java/com/echobox/github/cycletime/enrichment/jira/JIRAEpicWorkTypeEnricher.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.github.cycletime.enrichment.jira;
+
+import com.chavaillaz.jira.client.IssueClient;
+import com.chavaillaz.jira.client.JiraClient;
+import com.chavaillaz.jira.client.apache.ApacheHttpJiraClient;
+import com.chavaillaz.jira.domain.Issue;
+import com.echobox.github.cycletime.data.AnalysedPR;
+import com.echobox.github.cycletime.enrichment.PREnricher;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+
+/**
+ * Uses the ticket number at the start of a PR title and provided JIRA instance to determine the
+ * epic work type of the ticket. Expects a specific JIRA project structure to work.
+ * @author MarcF
+ */
+public class JIRAEpicWorkTypeEnricher implements PREnricher {
+  
+  /**
+   * The expected issue type name for an epic
+   */
+  private static final String EPIC_ISSUE_TYPE_NAME = "Epic";
+  
+  /**
+   * The expected structure of the issue key in the PR title;
+   */
+  private static final Pattern EXPECTED_ISSUE_KEY_PATTERN =
+      Pattern.compile("^[A-Z]{2,5}-[0-9]+$");
+  
+  private JiraClient<Issue> client;
+  private IssueClient<Issue> issueClient;
+  
+  public JIRAEpicWorkTypeEnricher(String jiraURL, String jiraLoginEmail, String jiraLoginAPIToken) {
+    client = ApacheHttpJiraClient.jiraApacheClient(jiraURL)
+        .withAuthentication(jiraLoginEmail, jiraLoginAPIToken);
+    issueClient = client.getIssueClient();
+  }
+  
+  @Override
+  public List<String> getEnrichmentHeaderNames() {
+    return Arrays.asList("JIRAEpicWorkType");
+  }
+  
+  @Override
+  public List<String> getEnrichments(AnalysedPR analysedPR)
+      throws ExecutionException, InterruptedException {
+
+    String issueKeyFromPRTitle = analysedPR.getPrTitle().split(" ")[0];
+    if (!EXPECTED_ISSUE_KEY_PATTERN.matcher(issueKeyFromPRTitle).matches()) {
+      throw new IllegalArgumentException("The PR title did not contain an issue key in the expected"
+          + " format.");
+    }
+
+    Issue currentIssue = issueClient.getIssue(issueKeyFromPRTitle).get();
+
+    while (!getIssueTypeName(currentIssue).equals(EPIC_ISSUE_TYPE_NAME)) {
+      currentIssue = issueClient.getIssue(getIssueParentKey(currentIssue)).get();
+    }
+    
+    String workType = getWorkTypeFieldFromEpicIssue(currentIssue);
+    
+    return Arrays.asList(workType);
+  }
+  
+  private static String getIssueParentKey(Issue issue) {
+    if (issue.getFields().getParent() != null) {
+      return issue.getFields().getParent().getKey();
+    } else {
+      return null;
+    }
+  }
+  
+  private static String getIssueTypeName(Issue issue) {
+    return issue.getFields().getIssueType().getName();
+  }
+
+  private static String getWorkTypeFieldFromEpicIssue(Issue epicIssue) {
+    if (!getIssueTypeName(epicIssue).equals(EPIC_ISSUE_TYPE_NAME)) {
+      throw new IllegalArgumentException("The provided issue is not an EPIC.");
+    }
+    
+    Map<String, Object> customFields = epicIssue.getFields().getCustomFields();
+    LinkedHashMap customfield12732 = (LinkedHashMap) customFields.get("customfield_12732");
+    String workType = (String) customfield12732.get("value");
+    return workType;
+  }
+}

--- a/src/main/java/com/echobox/github/cycletime/enrichment/jira/JIRAQueryHelper.java
+++ b/src/main/java/com/echobox/github/cycletime/enrichment/jira/JIRAQueryHelper.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.github.cycletime.enrichment.jira;
+
+import com.chavaillaz.jira.client.IssueClient;
+import com.chavaillaz.jira.client.JiraClient;
+import com.chavaillaz.jira.client.apache.ApacheHttpJiraClient;
+import com.chavaillaz.jira.domain.Issue;
+import com.chavaillaz.jira.domain.Issues;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A class for making JIRA queries
+ * @author MarcF
+ */
+public class JIRAQueryHelper {
+  
+  private static final Logger LOGGER = LogManager.getLogger();
+  
+  /**
+   * The maximum results we can get from the API in one request
+   */
+  private static final int MAX_RESULTS_PER_QUERY = 100;
+  
+  private JiraClient<Issue> client;
+  private IssueClient<Issue> issueClient;
+  
+  public JIRAQueryHelper(String jiraURL, String jiraLoginEmail, String jiraLoginAPIToken) {
+    client = ApacheHttpJiraClient.jiraApacheClient(jiraURL)
+        .withAuthentication(jiraLoginEmail, jiraLoginAPIToken);
+    issueClient = client.getIssueClient();
+  }
+  
+  public List<Issue> executeQuery(String query) throws ExecutionException, InterruptedException {
+    
+    List<Issue> results = new ArrayList<>();
+    int lastResultsNum = MAX_RESULTS_PER_QUERY;
+    
+    do {
+      Issues<Issue> issues =
+          client.getSearchClient().searchIssues(query, results.size(), MAX_RESULTS_PER_QUERY).get();
+      results.addAll(issues);
+      lastResultsNum = issues.size();
+      
+    } while (lastResultsNum == MAX_RESULTS_PER_QUERY);
+
+    return results;
+  }
+}


### PR DESCRIPTION
### Description of Changes

Changes initially started off as adding support for AnalysedPR.java to be enriched with additional (JIRA) data, i.e. `AnalysedPR.additionalEnrichments`, `PREnricher` interface and `JIRAEpicWorkTypeEnricher` implementation. Although these allow enrichments to be added at the time of the original export flow the majority of the changes were backed out as things got complicated and hard to iterate in future. What I've left in are potentially useful changes for the future, for example changes to `PullRequestCSVDAO` we're entirely to support a variable number of additional enrichment columns if needed.

The remaining changes in this PR were the final approach which aimed to build a dedicated CSV with the desired JIRA enrichments, childissues_to_epic.csv. It could fairly be argued that these changes are too Echobox specific and should be kept elsewhere. Rather than create a new repo for what is essentially one method in Main.java, `buildEpicTypesFromIssueKeysExport`, I've opted to keep this here for now and we can potentially break it out in future once we see how this functionality evolves further.

### Documentation

Not Applicable

### Risks & Impacts

If the expected environment variables are not provided then the impact would be zero.

### Testing

Have created a the childissues_to_epic.csv export of all issue keys for Echobox's data.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).