### PR TITLE
SDK-343 Update JQL to select 2024 issues when calculating child epics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 * Added optional analyser classes to allow for additional PR enrichment. For example with JIRA data.
 * After PR exports creates a cross reference lookup document named childissues_to_epic.csv which 
   can be used to determine work types for all tracked issues.
+
+## 2.0.1 (Jan 4, 2024)
+
+* Update the JQL statements to select 2024 issues only

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.echobox</groupId>
     <artifactId>ebx-github-cycletime</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/echobox/github/cycletime/Main.java
+++ b/src/main/java/com/echobox/github/cycletime/Main.java
@@ -92,7 +92,7 @@ public class Main {
       + "issuetype IN (Implementation, \"Implementation (Spec Gap)\", \"R&D\") and "
       + "status != \"Wont Fix\" AND summary !~ plan AND summary !~ Planning AND "
       + "summary !~ \"create technical\" "
-      + "AND created >= \"2023-01-01 00:00\" AND created <= \"2023-12-31 23:59\" ";
+      + "AND created >= \"2024-01-01 00:00\" AND created <= \"2024-12-31 23:59\" ";
   
   /**
    * The JIRA JQL that can be used to determine all R&D tickets. This is quite implementation
@@ -100,7 +100,7 @@ public class Main {
    */
   private static String JIRA_R_D_TICKETS_JQL = "project in (BM, PW, NL, SL, SDK) AND "
       + "issuetype IN (\"R&D\") AND status IN (Done, Resolved) "
-      + "AND updated >= \"2023-01-01 00:00\" AND updated <= \"2023-12-31 23:59\" ";
+      + "AND updated >= \"2024-01-01 00:00\" AND updated <= \"2024-12-31 23:59\" ";
   
   public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
### Description of Changes

Update JQL to select 2024 issues when calculating child epics to speed up the query

### Documentation

N/A

### Risks & Impacts

Low all other tickets are already cached in the `childissues_to_epic.csv` file

### Testing

Run to populate the new [Actions 2024](https://docs.google.com/spreadsheets/d/1qIWwtZVzngF_QuYSc7EOMORM7Dr6_LRvgTFETbwqnbQ/edit#gid=600613698) file

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.