### PR TITLE
SDK-361 Distinct PR reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@
 ## 2.0.1 (Jan 4, 2024)
 
 * Update the JQL statements to select 2024 issues only
+
+## 2.0.2 (April 18, 2024)
+
+* `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate` will only include distinct 
+  PR reviewers.

--- a/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
@@ -116,7 +116,10 @@ public class PullRequestCSVDAO implements AutoCloseable {
     String safeCSVTitle = StringEscapeUtils.escapeCsv(analysedPR.getPrTitle());
     String authorName = analysedPR.getPrAuthorStr();
     
-    List<String> prReviewedByList = analysedPR.getPrReviewedByList();
+    // Filter for distinct reviewers
+    List<String> prReviewedByList = analysedPR.getPrReviewedByList().stream()
+        .distinct()
+        .collect(Collectors.toList());
     Stream<String> reviewedByStream = prReviewedByList.stream().limit(MAX_REVIEWS);
     
     if (preferredAuthorNames != null) {


### PR DESCRIPTION
## Description of Changes
- Ensure distinct reviewers are exported as part of the PR export. This should not filter the data retrieved from Github but rather using the cached export as the point of filtering. 
- Note there is another incoming change in a separate PR which will be part of the 2.0.2 release.

### Documentation
- N/A

### Risks & Impacts
- Low as the export effected is the resulting export from the cached parent export `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate_filteredauthors.csv`.

### Testing
- Run to populate the new CSVs `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate_filteredauthors.csv`

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.