### PR TITLE
SDK-362 Exclude revert PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@
 
 * `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate` will only include distinct 
   PR reviewers.
+* `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate` will exclude revert PRs by 
+  excluding PRs with the word 'revert' in the title.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@
 ## 2.0.1 (Jan 4, 2024)
 
 * Update the JQL statements to select 2024 issues only
+
+## 2.0.2 (April 18, 2024)
+
+* `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate` will only include distinct 
+  PR reviewers.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.echobox</groupId>
     <artifactId>ebx-github-cycletime</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
@@ -116,7 +116,10 @@ public class PullRequestCSVDAO implements AutoCloseable {
     String safeCSVTitle = StringEscapeUtils.escapeCsv(analysedPR.getPrTitle());
     String authorName = analysedPR.getPrAuthorStr();
     
-    List<String> prReviewedByList = analysedPR.getPrReviewedByList();
+    // Filter for distinct reviewers
+    List<String> prReviewedByList = analysedPR.getPrReviewedByList().stream()
+        .distinct()
+        .collect(Collectors.toList());
     Stream<String> reviewedByStream = prReviewedByList.stream().limit(MAX_REVIEWS);
     
     if (preferredAuthorNames != null) {

--- a/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
+++ b/src/main/java/com/echobox/github/cycletime/data/PullRequestCSVDAO.java
@@ -189,7 +189,9 @@ public class PullRequestCSVDAO implements AutoCloseable {
     Iterable<CSVRecord> records = format.parse(csvReader);
   
     analysedPRs =  StreamSupport.stream(records.spliterator(), false)
-        .map(r -> parseRecord(r))
+        .map(this::parseRecord)
+        // PRs with the title containing the word 'revert' should be excluded from the exports
+        .filter(pr -> !pr.getPrTitle().toLowerCase().contains("revert"))
         .collect(Collectors.toList());
     
     return analysedPRs;


### PR DESCRIPTION
### Description of Changes
- When building the `export_sorted_by_mergedate.csv` and `export_sorted_by_mergedate_filterauthors.csv`, PRs where the title contains the word 'revert' should be excluded from the final exports. This does not filter the export CSV cached.
- The version has been bumped from `2.0.1` to `2.0.2`.

### Documentation
- N/A

### Risks & Impacts
- PRs with the word 'revert' in the title will be excluded in the PR exports, but not in the cached export built from Github.

### Testing
- Tested by building the CSV exports from the parent CSV.

### Compare (For layered PRs)

https://github.com/ebx/ebx-github-cycletime/compare/SDK-361-distinct-PR-reviewers...SDK-362-exclude-revert-prs

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.